### PR TITLE
fix(gcp/gcs-iap-proxy): some tweaks

### DIFF
--- a/modules/gcp/gcs-iap-proxy/main.tf
+++ b/modules/gcp/gcs-iap-proxy/main.tf
@@ -17,6 +17,7 @@ resource "google_service_account" "proxy_sa" {
 
 # Grant storage access to the service account
 resource "google_storage_bucket_iam_member" "proxy_storage_access" {
+  count  = var.bucket_name != "" ? 1 : 0
   bucket = var.bucket_name
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.proxy_sa.email}"
@@ -36,9 +37,12 @@ resource "google_cloud_run_v2_service" "gcs_proxy" {
       image = var.proxy_image
 
       # Core environment variables
-      env {
-        name  = "GCS_BUCKET"
-        value = var.bucket_name
+      dynamic "env" {
+        for_each = var.bucket_name != "" ? [1] : []
+        content {
+          name  = "GCS_BUCKET"
+          value = var.bucket_name
+        }
       }
 
       # SPA configuration

--- a/modules/gcp/gcs-iap-proxy/main.tf
+++ b/modules/gcp/gcs-iap-proxy/main.tf
@@ -109,6 +109,11 @@ resource "google_cloud_run_v2_service" "gcs_proxy" {
   # Configure ingress to only allow load balancer traffic
   ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
   labels = local.labels
 
   depends_on = [

--- a/modules/gcp/gcs-iap-proxy/variables.tf
+++ b/modules/gcp/gcs-iap-proxy/variables.tf
@@ -4,8 +4,9 @@ variable "namespace" {
 }
 
 variable "bucket_name" {
-  description = "The name of the GCS bucket to serve files from"
+  description = "The name of the GCS bucket to serve files from (optional)"
   type        = string
+  default     = ""
 }
 
 variable "region" {

--- a/modules/gcp/gcs-iap-proxy/variables.tf
+++ b/modules/gcp/gcs-iap-proxy/variables.tf
@@ -35,6 +35,7 @@ variable "iap_users" {
 variable "support_email" {
   description = "Support email for IAP OAuth consent screen"
   type        = string
+  default     = ""
 }
 
 variable "application_title" {


### PR DESCRIPTION
- Make passing a bucket name optional, in case proxy image is nginx bundled with the SPA static files
- Make sure latest revision is always serving `100%` of the traffic
- Make support email optional